### PR TITLE
#135 Delete corrupt APK files on upgrade

### DIFF
--- a/app/src/main/java/ai/elimu/appstore/util/VersionHelper.java
+++ b/app/src/main/java/ai/elimu/appstore/util/VersionHelper.java
@@ -54,7 +54,15 @@ public class VersionHelper {
                 }
             }
 
-//            if (oldVersionCode < 2000012) {
+            if (oldVersionCode < 2000018) {
+                // Delete downloaded APK files from SD card to prevent testers from having to manually delete corrupt files
+                File apkDirectory = new File(Environment.getExternalStorageDirectory() + "/.elimu-ai/appstore/apks/en/");
+                for (File apkFile : apkDirectory.listFiles()) {
+                    Timber.i("Deleted " + apkFile + ": " + apkFile.delete());
+                }
+            }
+
+//            if (oldVersionCode < 2000019) {
 //                ...
 //            }
 

--- a/app/src/main/java/ai/elimu/appstore/util/VersionHelper.java
+++ b/app/src/main/java/ai/elimu/appstore/util/VersionHelper.java
@@ -46,14 +46,6 @@ public class VersionHelper {
         if (oldVersionCode < newVersionCode) {
             Timber.i("Upgrading application from version " + oldVersionCode + " to " + newVersionCode + "...");
 
-            if (oldVersionCode < 2000011) {
-                // Delete downloaded APK files from SD card to prevent testers from having to manually delete corrupt files
-                File apkDirectory = new File(Environment.getExternalStorageDirectory() + "/.elimu-ai/appstore/apks/en/");
-                for (File apkFile : apkDirectory.listFiles()) {
-                    Timber.i("Deleted " + apkFile + ": " + apkFile.delete());
-                }
-            }
-
             if (oldVersionCode < 2000018) {
                 // Delete downloaded APK files from SD card to prevent testers from having to manually delete corrupt files
                 File apkDirectory = new File(Environment.getExternalStorageDirectory() + "/.elimu-ai/appstore/apks/en/");


### PR DESCRIPTION
Delete downloaded APK files from SD card to prevent testers from having
to manually delete corrupt files