### PR TITLE
Prepare GitHub workflow before upgrading to Java 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [11, 17]
+        java: [11, 17, 21]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        java: [11, 17, 21]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [11, 17]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,12 +11,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        java: [11, 17]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: ${{ matrix.java }}
     - uses: gradle/gradle-build-action@v3
     - run: ./gradlew clean build


### PR DESCRIPTION
Add Java 17 to GitHub workflow.

#254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the build process to support additional operating systems (including macOS) and multiple Java versions, increasing overall build compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->