### PR TITLE
feat: make download button stand out more

### DIFF
--- a/app/src/main/res/drawable/ic_baseline_download_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_download_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.49,2 2,6.49 2,12s4.49,10 10,10s10,-4.49 10,-10S17.51,2 12,2zM11,10V6h2v4h3l-4,4l-4,-4H11zM17,17H7v-2h10V17z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_save_alt_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_save_alt_24.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="?attr/colorControlNormal" android:viewportHeight="24"
-    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M19,12v7L5,19v-7L3,12v7c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2zM13,12.67l2.59,-2.58L17,11.5l-5,5 -5,-5 1.41,-1.41L11,12.67L11,3h2z"/>
-</vector>

--- a/app/src/main/res/layout/activity_application_list_item.xml
+++ b/app/src/main/res/layout/activity_application_list_item.xml
@@ -66,7 +66,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginStart="?attr/listPreferredItemPaddingStart"
-        android:drawableTop="@drawable/ic_baseline_save_alt_24"
+        android:drawableTop="@drawable/ic_baseline_download_24"
         android:drawableTint="@color/colorAccent"
         style="@style/Widget.AppCompat.Button.Borderless.Colored"
         android:text="@string/download" />
@@ -92,7 +92,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginStart="?attr/listPreferredItemPaddingStart"
-        android:drawableTop="@drawable/ic_baseline_save_alt_24"
+        android:drawableTop="@drawable/ic_baseline_download_24"
         android:drawableTint="@color/colorAccent"
         style="@style/Widget.AppCompat.Button.Borderless.Colored"
         android:text="@string/download_update" />


### PR DESCRIPTION
Adjust the UI so that the "DOWNLOAD" button stands out more, to indicate more clearly to the user that there is an update available for download.

Before/After

<img width=320 src="https://github.com/user-attachments/assets/3ac93b96-4d0b-481a-82ee-c8f51a6c4ae6" /> <img width=320 src="https://github.com/user-attachments/assets/a634a765-2fa8-47eb-b344-6a99af4cbe01" />


### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [ ] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)
