### PR TITLE
feat: add support for new package names

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,27 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="ai.elimu.appstore">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
-    <permission android:name="${applicationId}.provider.READ" />
+    <!-- Request permission to query any `ai.elimu.*` package. -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
 
-    <queries>
-        <package android:name="ai.elimu.vitabu"/>
-        <package android:name="ai.elimu.launcher"/>
-        <package android:name="ai.elimu.content_provider"/>
-        <package android:name="ai.elimu.analytics"/>
-        <package android:name="ai.elimu.kukariri"/>
-        <package android:name="org.dsandler.apps.markers"/>
-        <package android:name="com.eduapp4syria.feedthemonsterENGLISH"/>
-        <package android:name="ai.elimu.herufi"/>
-        <package android:name="com.google.fpl.liquidfunpaint"/>
-        <package android:name="ai.elimu.soundcards"/>
-        <package android:name="ai.elimu.imagepicker"/>
-        <package android:name="ai.elimu.filamu"/>
-    </queries>
+    <permission android:name="${applicationId}.provider.READ" />
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"


### PR DESCRIPTION
Add support for installing _new_ package names without having to release a new version of the Appstore app itself.

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #327
* Relates to https://github.com/elimu-ai/launcher/issues/139

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [x] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [x] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated app permissions to request access for querying all installed packages.
	- Adjusted manifest configuration to support the new permission setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->